### PR TITLE
Update 16-viz.mkd

### DIFF
--- a/book3/16-viz.mkd
+++ b/book3/16-viz.mkd
@@ -1,59 +1,59 @@
-Visualizing data
-================
+Visualización de datos
+======================
 
-So far we have been learning the Python language and then learning how
-to use Python, the network, and databases to manipulate data.
+Hasta el momento, hemos estudiado en primer lugar el lenguaje de Python y luego
+hemos aprendido a usar Python, la red y las bases de datos para manipular
+datos.
 
-In this chapter, we take a look at three complete applications that
-bring all of these things together to manage and visualize data. You
-might use these applications as sample code to help get you started in
-solving a real-world problem.
+En este capítulo, echaremos un vistazo a tres aplicaciones completas que usan
+todos estos elementos para gestionar y visualizar datos. Puedes usar estas aplicaciones
+como código de ejemplo que sirva de punto de partida para resolver
+problemas del mundo real.
 
-Each of the applications is a ZIP file that you can download and extract
-onto your computer and execute.
+Cada aplicación es un archivo ZIP que puedes descargar, extraer en
+tu equipo y ejecutar.
 
-Building a Google map from geocoded data
-----------------------------------------
+Construcción de un mapa de Google a partir de datos geocodificados
+------------------------------------------------------------------
 
-\index{Google!map}
-\index{Visualization!map}
+\index{Google!mapa}
+\index{Visualización!mapa}
 
-In this project, we are using the Google geocoding API to clean up some
-user-entered geographic locations of university names and then placing
-the data on a Google map.
+En este proyecto usaremos la API de geocodificación de Google para limpiar varias
+ubicaciones geográficas de nombres de universidades introducidas por los
+usuarios, y luego colocaremos los datos en un mapa de Google.
 
 ![A Google Map](../images/google-map)
 
-To get started, download the application from:
+Para comenzar, descarga la aplicación desde:
 
 [www.py4e.com/code3/geodata.zip](http://www.py4e.com/code3/geodata.zip)
 
-The first problem to solve is that the free Google geocoding API is
-rate-limited to a certain number of requests per day. If you have a lot
-of data, you might need to stop and restart the lookup process several
-times. So we break the problem into two phases.
+El primer problema a resolver es que la API libre de geocodificación de Google
+tiene como límite de uso un cierto número de peticiones diarias. Si tienes un
+montón de datos, necesitarás detener y reanudar el proceso de búsqueda varias
+veces. Por tanto, dividiremos el problema en dos fases.
 
 \index{cache}
 
-In the first phase we take our input "survey" data in the file
-*where.data* and read it one line at a time, and retrieve
-the geocoded information from Google and store it in a database
-*geodata.sqlite*. Before we use the geocoding API for
-each user-entered location, we simply check to see if we already have
-the data for that particular line of input. The database is functioning
-as a local "cache" of our geocoding data to make sure we never ask
-Google for the same data twice.
+En la primera fase, tomaremos como entrada los datos “de reconocimiento” del archivo
+*where.data* y los leeremos una línea a la vez, recuperando la información de 
+geocodificación desde Google y almacenándola en una base de datos *geodata.sqlite*.
+Antes de usar la API de geocodificación para cada ubicación introducida por el
+usuario, verificaremos si ya tenemos los datos para esa entrada concreta. La base
+de datos funcionará así como una "caché" local de datos de geocodificación, para
+asegurarnos de que nunca solicitamos a Google los mismos datos dos veces.
 
-You can restart the process at any time by removing the file
+Puedes reiniciar el proceso en cualquier momento eliminando el archivo
 *geodata.sqlite*.
 
-Run the *geoload.py* program. This program will read the
-input lines in *where.data* and for each line check to
-see if it is already in the database. If we don't have the data for the
-location, it will call the geocoding API to retrieve the data and store
-it in the database.
+Ejecuta el programa *geoload.py*. Este programa leerá las líneas de entrada desde
+*where.data* y para cada línea verificará si ya está en la base de datos. Si
+no disponemos de datos para esa ubicación, llamará a la API de geocodificación
+para recuperarlos y los almacenará en la base de datos.
 
-Here is a sample run after there is already some data in the database:
+Aquí tenemos un ejemplo de ejecución cuando ya disponemos de alguna información
+almacenada en la base de datos:
 
 ~~~~
 Found in database  Northeastern University
@@ -77,25 +77,24 @@ Retrieved 1749 characters {    "results" : [
 ...
 ~~~~
 
-The first five locations are already in the database and so they are
-skipped. The program scans to the point where it finds new locations and
-starts retrieving them.
+Las primeras cinco ubicaciones ya están en la base de datos y por eso las omitimos.
+El programa explora hasta que encuentra ubicaciones nuevas y entonces comienza
+a recuperarlas.
 
-The *geoload.py* program can be stopped at any time, and
-there is a counter that you can use to limit the number of calls to the
-geocoding API for each run. Given that the *where.data*
-only has a few hundred data items, you should not run into the daily
-rate limit, but if you had more data it might take several runs over
-several days to get your database to have all of the geocoded data for
-your input.
+El programa *geoload.py* puede ser detenido en cualquier momento, y dispone de
+un contador que puedes usar para limitar el número de llamadas a la API de
+geolocalización en cada ejecución. Dado que el archivo *where.data* solo tiene unos
+pocos cientos de elementos, no deberías llegar al límite diario de usos, pero si
+tienes más datos pueden ser necesarias varias ejecuciones del programa durante
+varios días para tener todos los datos de entrada geolocalizados en
+nuestra base de datos.
 
-Once you have some data loaded into *geodata.sqlite*, you
-can visualize the data using the *geodump.py* program.
-This program reads the database and writes the file
-*where.js* with the location, latitude, and longitude in
-the form of executable JavaScript code.
+Una vez que tienes parte de los datos cargados en *geodata.sqlite*, se pueden visualizar
+usando el programa *geodump.py*. Este programa lee la base de datos y
+escribe el arhivo *where.js* con la ubicación, latitud y longitud en forma de código
+ejecutable de JavaScript.
 
-A run of the *geodump.py* program is as follows:
+Una ejecución del programa *geodump.py* sería la siguiente:
 
 ~~~~
 Northeastern University, ... Boston, MA 02115, USA 42.3396998 -71.08975
@@ -109,10 +108,9 @@ Kokshetau, Kazakhstan 53.2833333 69.3833333
 Open where.html to view the data in a browser
 ~~~~
 
-The file *where.html* consists of HTML and JavaScript to
-visualize a Google map. It reads the most recent data in
-*where.js* to get the data to be visualized. Here is the
-format of the *where.js* file:
+El archivo *where.html* consiste en HTML y JavaScript para mostrar un mapa de
+Google. Lee los datos más actuales de *where.js* para obtener los datos que se
+mostrarán. He aquí el formato del archivo *where.js*:
 
 ~~~~ {.js}
 myData = [
@@ -123,43 +121,41 @@ myData = [
 ];
 ~~~~
 
-This is a JavaScript variable that contains a list of lists. The syntax
-for JavaScript list constants is very similar to Python, so the syntax
-should be familiar to you.
+Se trata de una variable JavaScript que contiene una lista de listas. La sintaxis de
+las listas de constantes en JavaScript es muy similar a las de Python, de modo que
+debería resultarte familiar.
 
-Simply open *where.html* in a browser to see the
-locations. You can hover over each map pin to find the location that the
-geocoding API returned for the user-entered input. If you cannot see any
-data when you open the *where.html* file, you might want
-to check the JavaScript or developer console for your browser.
+Simplemente abre *where.html* en un navegador para ver las ubicaciones. Puedes
+mantener el ratón sobre cada marca del mapa para ver la ubicación que la API de
+geocodificación ha devuelto para la entrada que el usuario introdujo. Si no puedes
+ver ningún dato cuando abras el archivo *where.html*, puede que debas revisar
+JavaScript o la consola de desarrollador de tu navegador.
 
-Visualizing networks and interconnections
------------------------------------------
+Visualización de redes e interconexiones
+----------------------------------------
 
 \index{Google!page rank}
 \index{Visualization!networks}
 \index{Visualization!page rank}
 
-In this application, we will perform some of the functions of a search
-engine. We will first spider a small subset of the web and run a
-simplified version of the Google page rank algorithm to determine which
-pages are most highly connected, and then visualize the page rank and
-connectivity of our small corner of the web. We will use the D3
-JavaScript visualization library <http://d3js.org/> to produce the
-visualization output.
+En esta aplicación, realizaremos algunas de las funciones de un motor de
+búsqueda. Primero rastrearemos una pequeña parte de la web y ejecutaremos una
+versión simplificada del algoritmo de clasificación que usa Google
+para determinar qué páginas se encuentran más conectadas. Luego, visualizaremos la 
+clasificación de las páginas y conectividad de nuestro pequeño rincón de la web. Usaremos
+la librería de visualización de JavaScript D3 <http://d3js.org/> para generar la
+imagen de salida.
 
-You can download and extract this application from:
+Puedes descargar y extraer esta aplicación desde:
 
 [www.py4e.com/code3/pagerank.zip](http://www.py4e.com/code3/pagerank.zip)
 
 ![A Page Ranking](height=3.5in@../images/pagerank)
 
-The first program (*spider.py*) program crawls a web site
-and pulls a series of pages into the database
-(*spider.sqlite*), recording the links between pages. You
-can restart the process at any time by removing the
-*spider.sqlite* file and rerunning
-*spider.py*.
+El primer programa (*spider.py*) rastrea un sitio web y envía una serie de páginas
+a la base de datos (*spider.sqlite*), guardando los enlaces entre páginas. Puedes
+reiniciar el proceso en cualquier momento eliminando el fichero *spider.sqlite* y
+ejecutando de nuevo *spider.py*.
 
 ~~~~
 Enter web url or enter: http://www.dr-chuck.com/
@@ -170,11 +166,11 @@ How many pages:2
 How many pages:
 ~~~~
 
-In this sample run, we told it to crawl a website and retrieve two
-pages. If you restart the program and tell it to crawl more pages, it
-will not re-crawl any pages already in the database. Upon restart it
-goes to a random non-crawled page and starts there. So each successive
-run of *spider.py* is additive.
+En esta ejecución de ejemplo, le pedimos que rastree un sitio web y que recupere
+dos páginas. Si reinicias el programa y le pides que rastree más páginas, no volverá
+a revisar aquellas que ya estén en la base de datos. En cada reinicio elegirá una
+página al azar no rastreada aún y comenzará allí. De modo que cada ejecución
+sucesiva de *spider.py* irá añadiendo páginas nuevas.
 
 ~~~~
 Enter web url or enter: http://www.dr-chuck.com/
@@ -186,12 +182,12 @@ How many pages:3
 How many pages:
 ~~~~
 
-You can have multiple starting points in the same database—within the
-program, these are called "webs". The spider chooses randomly amongst
-all non-visited links across all the webs as the next page to spider.
+Se pueden tener múltiples puntos de partida en la misma base de datos —dentro
+del programa, éstos son llamados "webs". La araña elige entre todos los enlaces no
+visitados de las páginas existentes uno al azar como siguiente página a rastrear.
 
-If you want to dump the contents of the *spider.sqlite*
-file, you can run *spdump.py* as follows:
+Si quieres ver el contenido del archivo *spider.sqlite*, puedes ejecutar *spdump.py*,
+que mostrará algo como esto:
 
 ~~~~
 (5, None, 1.0, 3, 'http://www.dr-chuck.com/csev-blog')
@@ -201,14 +197,14 @@ file, you can run *spdump.py* as follows:
 4 rows.
 ~~~~
 
-This shows the number of incoming links, the old page rank, the new page
-rank, the id of the page, and the url of the page. The
-*spdump.py* program only shows pages that have at least
-one incoming link to them.
+Esto muestra el número de enlaces hacia la página, la clasificación antigua de la
+página, la clasificación nueva, el id de la página, y la url de la página. El programa
+*spdump.py* sólo muestra aquellas páginas que tienen al menos un enlace hacia
+ella.
 
-Once you have a few pages in the database, you can run page rank on the
-pages using the *sprank.py* program. You simply tell it
-how many page rank iterations to run.
+Una vez que tienes unas cuantas páginas en la base de datos, puedes ejecutar el
+clasificador sobre ellas, usando el programa *sprank.py*. Simplemente debes indicarle
+cuántas iteraciones del clasificador de páginas debe realizar.
 
 ~~~~
 How many iterations:2
@@ -217,7 +213,8 @@ How many iterations:2
 [(1, 0.559), (2, 0.659), (3, 0.985), (4, 2.135), (5, 0.659)]
 ~~~~
 
-You can dump the database again to see that page rank has been updated:
+Puedes volcar en pantalla el contenido de la base de datos de nuevo para ver que
+la clasificación de páginas ha sido actualizada:
 
 ~~~~
 (5, 1.0, 0.985, 3, 'http://www.dr-chuck.com/csev-blog')
@@ -227,16 +224,15 @@ You can dump the database again to see that page rank has been updated:
 4 rows.
 ~~~~
 
-You can run *sprank.py* as many times as you like and it
-will simply refine the page rank each time you run it. You can even run
-*sprank.py* a few times and then go spider a few more
-pages sith *spider.py* and then run
-*sprank.py* to reconverge the page rank values. A search
-engine usually runs both the crawling and ranking programs all the time.
+Puedes ejecutar *sprank.py* tantas veces como quieras, y simplemente irá refinando
+la clasificación de páginas cada vez más. Puedes incluso ejecutar *sprank.py*
+varias veces, luego ir a la araña *spider.py* a recuperar unas cuantas páginas más y
+después ejecutar de nuevo *sprank.py* para actualizar los valores de clasificación.
+Un motor de búsqueda normalmente ejecuta ambos programas (el rastreador y el
+clasificador) de forma constante.
 
-If you want to restart the page rank calculations without respidering
-the web pages, you can use *spreset.py* and then restart
-*sprank.py*.
+Si quieres reiniciar los cálculos de clasificación de páginas sin tener que rastrear
+de nuevo las páginas web, puedes usar *spreset.py* y después reiniciar *sprank.py*.
 
 ~~~~
 How many iterations:50
@@ -259,17 +255,16 @@ How many iterations:50
 [(512, 0.0296), (1, 12.79), (2, 28.93), (3, 6.808), (4, 13.46)]
 ~~~~
 
-For each iteration of the page rank algorithm it prints the average
-change in page rank per page. The network initially is quite unbalanced
-and so the individual page rank values change wildly between iterations.
-But in a few short iterations, the page rank converges. You should run
-*sprank.py* long enough that the page rank values
-converge.
+En cada iteración del algoritmo de clasificación de páginas se muestra el cambio
+medio en la clasificación de cada página. La red al principio está bastante desequilibrada,
+de modo que los valores de clasificación para cada página cambiarán mucho entre
+iteraciones. Pero después de unas cuantas iteraciones, la clasificación de páginas
+converge. Deberías ejecutar *prank.py* durante el tiempo suficiente para que los 
+valores de clasificación converjan.
 
-If you want to visualize the current top pages in terms of page rank,
-run *spjson.py* to read the database and write the data
-for the most highly linked pages in JSON format to be viewed in a web
-browser.
+Si quieres visualizar las páginas mejor clasificadas, ejecuta
+*spjson.py* para leer la base de datos y escribir el ranking de las páginas más
+enlazadas en formato JSON, que puede ser visualizado en un navegador web.
 
 ~~~~
 Creating JSON output on spider.json...
@@ -282,69 +277,66 @@ in your web browser. This shows an automatic layout of the nodes and
 links. You can click and drag any node and you can also double-click on
 a node to find the URL that is represented by the node.
 
-If you rerun the other utilities, rerun *spjson.py* and
-press refresh in the browser to get the new data from
-*spider.json*.
+Si vuelves a ejecutar las otras utilidades, ejecuta de nuevo *spjson.py* y pulsa actualizar
+en el navegador para obtener los datos actualizados desde *spider.json*.
 
-Visualizing mail data
----------------------
+Visualización de datos de correo
+--------------------------------
 
-Up to this point in the book, you have become quite familiar with our
-*mbox-short.txt* and *mbox.txt* data
-files. Now it is time to take our analysis of email data to the next
-level.
+Si has llegado hasta este punto del libro, ya debes de estar bastante familiarizado
+con nuestros ficheros de datos *mbox-short.txt* y *mbox.txt*. Ahora es el momento
+de llevar nuestro análisis de datos de correo electrónico al siguiente nivel.
 
-In the real world, sometimes you have to pull down mail data from
-servers. That might take quite some time and the data might be
-inconsistent, error-filled, and need a lot of cleanup or adjustment. In
-this section, we work with an application that is the most complex so
-far and pull down nearly a gigabyte of data and visualize it.
+En el mundo real, a veces se tienen que descargar datos de correo desde los servidores.
+Eso podría llevar bastante tiempo y los datos podrían tener inconsistencias,
+estar llenos de errores, y necesitar un montón de limpieza y ajustes. En esta sección, 
+trabajaremos con la aplicación más compleja que hemos visto hasta ahora,
+que descarga casi un gigabyte de datos y los visualiza.
 
 ![A Word Cloud from the Sakai Developer List](height=3.5in@../images/wordcloud)
 
-You can download this application from:
+Puedes descargar la aplicación desde:
 
 [www.py4e.com/code3/gmane.zip](http://www.py4e.com/code3/gmane.zip)
 
-We will be using data from a free email list archiving service called
-[www.gmane.org](http://www.gmane.org). This service is very popular with open
-source projects because it provides a nice searchable archive of their
-email activity. They also have a very liberal policy regarding accessing
-their data through their API. They have no rate limits, but ask that you
-don't overload their service and take only the data you need. You can
-read gmane's terms and conditions at this page:
+Utilizaremos los datos de un servicio de archivo de listas de correo electrónico
+libre, llamado [www.gmane.org](http://www.gmane.org). Este servicio es muy popular 
+en proyectos de código abierto, debido a que proporciona un buen almacenaje con 
+capacidad de búsqueda de su actividad de correo. También tienen una política muy 
+liberal respecto al acceso a los datos a través de su API. No tienen límites de 
+acceso, pero te piden que no sobrecargues su servicio y descargues sólo 
+aquellos datos que necesites. Puedes leer los términos y condiciones de 
+gmane en su página:
 
 <http://gmane.org/export.php>
 
-*It is very important that you make use of the gmane.org data
-responsibly by adding delays to your access of their services and
-spreading long-running jobs over a longer period of time. Do not abuse
-this free service and ruin it for the rest of us.*
+*Es muy importante que hagas uso de los datos de gname.org con responsabilidad,
+añadiendo retrasos en tu acceso a sus servicios y extendiendo la realización de
+los procesos de larga duración a periodos de tiempo lo suficientemente largos. No
+abuses de este servicio libre y lo estropees para los demás.*
 
-When the Sakai email data was spidered using this software, it produced
-nearly a Gigabyte of data and took a number of runs on several days. The
-file *README.txt* in the above ZIP may have instructions
-as to how you can download a pre-spidered copy of the
-*content.sqlite* file for a majority of the Sakai email
-corpus so you don't have to spider for five days just to run the
-programs. If you download the pre-spidered content, you should still run
-the spidering process to catch up with more recent messages.
+Al usar este software para rastrear los datos de correo de Sakai, se generó
+casi un gigabyte de datos, requiriendo una cantidad considerable de ejecuciones
+durante varios días. El archivo *README.txt* del ZIP anterior contiene instrucciones
+sobre cómo descargar una copia pre-rastreada del archivo *content.sqlite*
+con la mayor parte del contenido de los correos de Sakai, de modo que no tengas
+que rastrear durante cinco días sólo para hacer funcionar los programas. Aunque
+descargues el contenido pre-rastreado, deberías ejecutar el proceso de rastreo para
+recuperar los mensajes más recientes.
 
-The first step is to spider the gmane repository. The base URL is
-hard-coded in the *gmane.py* and is hard-coded to the
-Sakai developer list. You can spider another repository by changing that
-base url. Make sure to delete the *content.sqlite* file
-if you switch the base url.
+El primer paso es rastrear el repositorio gmane. La URL base se puede modificar
+en *gmane.py*, y por defecto apunta a la lista de desarrolladores de Sakai. Puedes
+rastrear otro repositorio cambiando la url base. Asegúrate de borrar el fichero
+*content.sqlite* si realizas el cambio de url.
 
-The *gmane.py* file operates as a responsible caching
-spider in that it runs slowly and retrieves one mail message per second
-so as to avoid getting throttled by gmane. It stores all of its data in
-a database and can be interrupted and restarted as often as needed. It
-may take many hours to pull all the data down. So you may need to
-restart several times.
+El archivo *gmane.py* opera como una araña caché responsable, que funciona despacio
+y recupera un mensaje de correo por segundo para evitar ser bloqueado por
+gmane. Almacena todos sus datos en una base de datos y puede ser interrumpido
+y reanudado tantas veces como sean necesarias. Puede llevar muchas horas
+descargar todos los datos. De modo que quizá debas reanudarlo varias veces.
 
-Here is a run of *gmane.py* retrieving the last five
-messages of the Sakai developer list:
+He aquí una ejecución de *mane.py* recuperando los últimos cinco mensajes de la
+lista de desarrolladores de Sakai:
 
 ~~~~
 How many messages:10
@@ -363,46 +355,41 @@ http://download.gmane.org/gmane.comp.cms.sakai.devel/51415/51416 0
 Does not start with From
 ~~~~
 
-The program scans *content.sqlite* from one up to the
-first message number not already spidered and starts spidering at that
-message. It continues spidering until it has spidered the desired number
-of messages or it reaches a page that does not appear to be a properly
-formatted message.
+El programa revisa *content.sqlite* desde el principio hasta que encuentra un número
+de mensaje que aún no ha sido rastreado y comienza a partir de ahí. Continúa
+rastreando hasta que ha recuperado el número deseado de mensajes o hasta que
+llega a una página que no contiene un mensaje adecuadamente formateado.
 
-Sometimes [gmane.org](gmane.org) is missing a message. Perhaps
-administrators can delete messages or perhaps they get lost. If your
-spider stops, and it seems it has hit a missing message, go into the
-SQLite Manager and add a row with the missing id leaving all the other
-fields blank and restart *gmane.py*. This will unstick
-the spidering process and allow it to continue. These empty messages
-will be ignored in the next phase of the process.
+A veces [gmane.org](gmane.org) no encuentra un mensaje. Tal vez los administradores lo borraron,
+o quizás simplemente se perdió. Si tu araña se detiene, y parece que se
+atasca en un mensaje que no puede localizar, entra en SQLite Manager, añade
+una fila con el id perdido y los demás campos en blanco y reinicia *gmane.py*.
+Así se desbloqueará el proceso de rastreo y podrá continuar. Esos mensajes vacíos
+serán ignorados en la siguiente fase del proceso.
 
-One nice thing is that once you have spidered all of the messages and
-have them in *content.sqlite*, you can run
-*gmane.py* again to get new messages as they are sent to
-the list.
+Algo bueno es que una vez que has rastreado todos los mensajes y los tienes en
+*content.sqlite*, puedes ejecutar *gmane.py* otra vez para obtener los mensajes nuevos
+según van siendo enviados a la lista.
 
-The *content.sqlite* data is pretty raw, with an
-inefficient data model, and not compressed. This is intentional as it
-allows you to look at *content.sqlite* in the SQLite
-Manager to debug problems with the spidering process. It would be a bad
-idea to run any queries against this database, as they would be quite
-slow.
+Los datos en *content.sqlite* están guardados en bruto, con un modelado de datos
+ineficiente y sin comprimir. Esto se ha hecho así intencionadamente, para permitirte
+echar un vistazo en *content.sqlite* usando SQLite Manager y depurar
+problemas con el proceso de rastreo. Sería mala idea ejecutar consultas
+sobre esta base de datos, ya que puede resultar bastante lenta.
 
-The second process is to run the program *gmodel.py*.
-This program reads the raw data from *content.sqlite* and
-produces a cleaned-up and well-modeled version of the data in the file
-*index.sqlite*. This file will be much smaller (often 10X
-smaller) than *content.sqlite* because it also compresses
-the header and body text.
+El segundo proceso consiste en ejecutar el programa *gmodel.py*. Este programa
+lee los datos en bruto de *content.sqlite* y produce una versión limpia y bien modelada
+de los datos, que envía al fichero *index.sqlite*. Este fichero es mucho más
+pequeño (puede ser 10 veces menor) que *content.sqlite*, porque también comprime
+la cabecera y el texto del cuerpo.
 
-Each time *gmodel.py* runs it deletes and rebuilds
-*index.sqlite*, allowing you to adjust its parameters and
-edit the mapping tables in *content.sqlite* to tweak the
-data cleaning process. This is a sample run of
-*gmodel.py*. It prints a line out each time 250 mail
-messages are processed so you can see some progress happening, as this
-program may run for a while processing nearly a Gigabyte of mail data.
+Cada vez que *gmodel.py* se ejecuta, borra y reconstruye *index.sqlite*. Esto permite
+ajustar sus parámetros y editar las tablas de asignación de *content.sqlite*
+para ajustar el proceso de limpieza de datos. Esto es un ejemplo de ejecución de
+*gmodel.py*. El programa imprime una línea en pantalla cada vez que son procesados
+250 mensajes de correo para que puedas ver su evolución, ya que puede
+quedarse funcionando durante un buen rato mientras procesa alrededor de un Gigabyte
+de datos de correo.
 
 ~~~~
 Loaded allsenders 1588 and mapping 28 dns mapping 1
@@ -416,23 +403,24 @@ Loaded allsenders 1588 and mapping 28 dns mapping 1
 The *gmodel.py* program handles a number of data cleaning
 tasks.
 
-Domain names are truncated to two levels for .com, .org, .edu, and .net.
-Other domain names are truncated to three levels. So si.umich.edu
-becomes umich.edu and caret.cam.ac.uk becomes cam.ac.uk. Email addresses
-are also forced to lower case, and some of the @gmane.org address like
-the following
+Los nombres de dominio son truncados a dos niveles para .com, .org, .edu y
+.net. Otros nombres de dominio son truncados a tres niveles. De modo que
+si.umich.edu se transforma en umich.edu, y caret.cam.ac.uk queda como
+cam.ac.uk. Las direcciones de correo electrónico también son transformadas a
+minúsculas, y algunas de las direcciones de @gmane.org, como la siguiente
 
 ~~~~
 arwhyte-63aXycvo3TyHXe+LvDLADg@public.gmane.org
 ~~~~
-are converted to the real address whenever there is a matching real
-email address elsewhere in the message corpus.
 
-In the *mapping.sqlite* database there are two tables
-that allow you to map both domain names and individual email addresses
-that change over the lifetime of the email list. For example, Steve
-Githens used the following email addresses as he changed jobs over the
-life of the Sakai developer list:
+son convertidas en direcciones reales, cuando esa dirección de correo real existe
+en otra parte del cuerpo del mensaje.
+
+En la base de datos *mapping.sqlite* existen dos tablas que te permiten asignar tanto
+nombres de dominios como direcciones de correo individuales que van cambiando
+a lo largo del tiempo de existencia de la lista de correo. Por ejemplo, Steve Githens
+ha usado las direcciones de correo siguientes, según iba cambiando de trabajo a lo
+largo de la existencia de la lista de desarrolladores de Sakai:
 
 ~~~~
 s-githens@northwestern.edu
@@ -440,35 +428,34 @@ sgithens@cam.ac.uk
 swgithen@mtu.edu
 ~~~~
 
-We can add two entries to the Mapping table in
-*mapping.sqlite* so *gmodel.py* will map
-all three to one address:
+Podemos añadir dos entradas en la tabla de asignación (Mapping) de *mapping.sqlite*, 
+de modo que gmodel.py enlazará las tres direcciones en una:
 
 ~~~~
 s-githens@northwestern.edu ->  swgithen@mtu.edu
 sgithens@cam.ac.uk -> swgithen@mtu.edu
 ~~~~
 
-You can also make similar entries in the DNSMapping table if there are
-multiple DNS names you want mapped to a single DNS. The following
-mapping was added to the Sakai data:
+Puedes crear entradas similares en la tabla DNSMapping si hay múltiples nombres
+DNS que quieres asignar a una única DNS. En los datos de Sakai se ha realizado
+la siguiente asignación:
 
 ~~~~
 iupui.edu -> indiana.edu
 ~~~~
 
-so all the accounts from the various Indiana University campuses are
-tracked together.
+de modo que todas las cuentas de los distintos campus de las Universidades de
+Indiana son monitoreadas juntas.
 
-You can rerun the *gmodel.py* over and over as you look
-at the data, and add mappings to make the data cleaner and cleaner. When
-you are done, you will have a nicely indexed version of the email in
-*index.sqlite*. This is the file to use to do data
-analysis. With this file, data analysis will be really quick.
+Puedes volver a ejecutar *gmodel.py* una y otra vez mientras vas mirando los datos,
+y añadir asignaciones para hacer que los datos queden más y más limpios. Cuando
+lo hayas hecho, tendrás una bonita versión indexada del correo en *index.sqlite*.
+Éste es el archivo que usaremos para analizar los datos. Con ese archivo, el análisis
+de datos se realizará muy rápidamente.
 
-The first, simplest data analysis is to determine "who sent the most
-mail?" and "which organization sent the most mail"? This is done using
-*gbasic.py*:
+El primer y más sencillo análisis de datos consistirá en determinar "¿Quién ha
+enviado más correos?", y "¿Qué organización ha enviado más correos?". Esto se
+realizará usando *gbasic.py*:
 
 ~~~~
 How many to dump? 5
@@ -489,28 +476,27 @@ indiana.edu 2258
 unicon.net 2055
 ~~~~
 
-Note how much more quickly *gbasic.py* runs compared to
-*gmane.py* or even *gmodel.py*. They are
-all working on the same data, but *gbasic.py* is using
-the compressed and normalized data in *index.sqlite*. If
-you have a lot of data to manage, a multistep process like the one in
-this application may take a little longer to develop, but will save you
-a lot of time when you really start to explore and visualize your data.
+Fijate cómo *gbasic.py* funciona mucho más rápido que *gmane.py*, e incluso que
+*gmodel.py*. Todos trabajan con los mismos datos, pero *gbasic.py* está usando los
+datos comprimidos y normalizados de *index.sqlite*. Si tienes un montón de datos
+que gestionar, un proceso multipaso como el que se realiza en esta aplicación
+puede ser más largo de desarrollar, pero te ahorrará un montón de tiempo cuando
+realmente comiences a explorar y visualizar los datos.
 
-You can produce a simple visualization of the word frequency in the
-subject lines in the file *gword.py*:
+
+Puedes generar una vista sencilla con la frecuencia de cada palabra en las líneas
+de título, usando el archivo *gword.py*:
 
 ~~~~
 Range of counts: 33229 129
 Output written to gword.js
 ~~~~
 
-This produces the file *gword.js* which you can visualize
-using *gword.htm* to produce a word cloud similar to the
-one at the beginning of this section.
+Esto genera el archivo *gword.js*, que puedes visualizar utilizando *gword.htm* para
+producir una nube de palabras similar a la del comienzo de esta sección.
 
-A second visualization is produced by *gline.py*. It
-computes email participation by organizations over time.
+*gline.py* genera también una segunda vista. En este caso cuenta la participación
+en forma de correos de las organizaciones a lo largo del tiempo.
 
 ~~~~
 Loaded messages= 51330 subjects= 25033 senders= 1584
@@ -521,10 +507,9 @@ Top 10 Oranizations
 Output written to gline.js
 ~~~~
 
-Its output is written to *gline.js* which is visualized
-using *gline.htm*.
+Su resultado es guardado en *gline.js*, que se puede visualizar usando *gline.htm*.
 
 ![Sakai Mail Activity by Organization](../images/mailorg)
 
-This is a relatively complex and sophisticated application and has
-features to do some real data retrieval, cleaning, and visualization.
+Esta aplicación es relativamente compleja y sofisticada, y dispone de características
+para realizar recuperación de datos reales, limpieza y visualización.


### PR DESCRIPTION
Traducido el capítulo completo, usando de base la edición anterior del libro en español.

 Tuve especial cuidado en mantener el formato y dejar tanto las comillas como los backticks. donde resultaba necesario,
en la misma configuración que el original.

Líneas 419 y 431/432 mencionan mapping.sqlite, mientras la versión en español menciona content.sqlite. Opero bajo el supuesto de que la versión original es la correcta, pero podría valer la pena revisar.