### PR TITLE
Update podcasts.htm

### DIFF
--- a/podcasts.htm
+++ b/podcasts.htm
@@ -2,7 +2,7 @@
      "DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-  <title>SI182: Building Applications for Information Environments</title>
+  <title>SI182: Construyendo Aplicaciones para Ambientes Informáticos</title>
 <link rel="stylesheet" href="style.css" type="text/css">
 <link rel="alternate" type="application/atom+xml" title="SI182 Podcast" 
 href="https://ctools.umich.edu/podcasts/site/8a0551bf-5d66-4a39-004b-3a90ff183423" />
@@ -10,12 +10,12 @@ href="https://ctools.umich.edu/podcasts/site/8a0551bf-5d66-4a39-004b-3a90ff18342
 <body>
 <div id="footer">
 <ul>
-<li><a href=index.htm>About SI182</a> |</li>
-<li><a href=book.htm>Book</a> |</li>
-<li><a href=resources.htm>Resources</a> |</li>
-<li><a href=resources.htm>Course Resources</a> |</li>
-<li><a href=course.htm>Course Site</a> |</li>
-<li><a href=http://www.dr-chuck.com/ target=_new>Instructor Page</a> |</li>
+<li><a href=index.htm>Acerca de SI182</a> |</li>
+<li><a href=book.htm>Libro</a> |</li>
+<li><a href=resources.htm>Recursos</a> |</li>
+<li><a href=resources.htm>Recursos ara el Curso</a> |</li>
+<li><a href=course.htm>Sitio del Curso</a> |</li>
+<li><a href=http://www.dr-chuck.com/ target=_new>Página del Profesor</a> |</li>
 <li><a href=http://www.python.org/ target=_new>Python</a></li>
 </ul>
 </div>
@@ -26,20 +26,20 @@ href="https://ctools.umich.edu/podcasts/site/8a0551bf-5d66-4a39-004b-3a90ff18342
 </a>
 SI182 Podcasts</h1>
 <p>
-This course has a number of podcasts for the lectures and homework exercises that allow you to follow along in the course.
+Este curso tiene algunos podcasts relativos a las clases y ejercicios de tareas, los que puedes seguir junto con el curso.
 <p>
-The podcast URL for this course is:
+La URL del podcast sobre este curso es:
 </p>
 <p>
 <a href=https://ctools.umich.edu/podcasts/site/8a0551bf-5d66-4a39-004b-3a90ff183423 target="_new">https://ctools.umich.edu/podcasts/site/8a0551bf-5d66-4a39-004b-3a90ff183423</a>
 </p>
 <p>
-In most browsers, you should see an icon in your browser's address bar indicating that there is a podcast available for this site.
+En la mayor parte de los exploradores, deberías ver un ícono en la barra de direcciones, indicando que hay un podcast disponible para este sitio.
 </p>
-Some browsers (Including Safari, Firefox, and Internet Explorer 7) can simply open this URL 
-to browse the Podcast and even subscribe to the podcast.  
-Internet Explorer 6 and earlier will just show you the XML RSS feed when you click on this link so don't be alarmed - 
-you need ot subscribe to the feed using iTunes or some other podcatcher.
+En algunos navegadores (incluyendo Safari, Firefox e Internet Explorer 8) puedes simplemente abrir esta URL
+para acceder al podcast o suscribirte.
+Internet Explorer 6 o anterior solo te mostrará el feed de XML RSS al hacer click en el enlace, así que no te alarmes -
+debes suscribirte al feed usando iTunes o algún software enfocado a podcasts.
 <iframe
 height="1800" width="100%" frameborder="0" marginwidth="0"
 marginheight="0" scrolling="auto"


### PR DESCRIPTION
Traducido al español. 
Líneas 41, 42. No se como traducir feed en sentido adecuado, y una búsqueda en linguee.es no dio resultados útiles, por lo que la dejo tal cual. Como siempre, quedo atento a fin de efectuar la modificación que resulte pertinente.
 Línea 42, algo similar sucede con "podcatcher", lo traduje provisoriamente como "algún software enfocado a podcasts".